### PR TITLE
Fix a bug with public ips

### DIFF
--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -48,6 +48,7 @@ module "bastion_host" {
   root_vl_size           = "${var.root_vl_size}"
   root_vl_delete         = "${var.root_vl_delete}"
   user_data              = "${var.user_data}"
+  public_ip              = true
 }
 
 resource "aws_eip" "bastion_eip" {


### PR DESCRIPTION
My EIP wouldn't attach to my instance. After some investigating I found out that the public_ip needs to be true. I added my eip manually ran terraform plan and got this:

```
-/+ module.bastion.bastion_host.aws_instance.instance
    ami:                                       "ami-f7287c84" => "ami-f7287c84"
    associate_public_ip_address:               "true" => "false" (forces new resource)
    availability_zone:                         "eu-west-1a" => "<computed>"
    disable_api_termination:                   "false" => "false"
    ebs_block_device.#:                        "0" => "<computed>"
    ebs_optimized:                             "false" => "false"
    ephemeral_block_device.#:                  "0" => "<computed>"
    iam_instance_profile:                      "profile_bastion_otakeys_staging" => "profile_bastion_otakeys_staging"
    instance_state:                            "running" => "<computed>"
    instance_type:                             "t2.micro" => "t2.micro"
    key_name:                                  "" => "<computed>"
    network_interface_id:                      "eni-db8a80a1" => "<computed>"
    placement_group:                           "" => "<computed>"
    private_dns:                               "ip-10-11-0-133.eu-west-1.compute.internal" => "<computed>"
    private_ip:                                "10.11.0.133" => "<computed>"
    public_dns:                                "ec2-52-210-87-168.eu-west-1.compute.amazonaws.com" => "<computed>"
    public_ip:                                 "52.210.87.168" => "<computed>"
    root_block_device.#:                       "1" => "1"
    root_block_device.0.delete_on_termination: "true" => "true"
    root_block_device.0.iops:                  "100" => "<computed>"
    root_block_device.0.volume_size:           "30" => "30"
    root_block_device.0.volume_type:           "gp2" => "gp2"
    security_groups.#:                         "0" => "<computed>"
    source_dest_check:                         "true" => "true"
    subnet_id:                                 "subnet-5fe4a43b" => "subnet-5fe4a43b"
    tags.%:                                    "3" => "3"
    tags.Environment:                          "staging" => "staging"
    tags.Name:                                 "otakeys-staging-bastion1" => "otakeys-staging-bastion1"
    tags.Project:                              "otakeys" => "otakeys"
    tenancy:                                   "default" => "<computed>"
    user_data:                                 "da39a3ee5e6b4b0d3255bfef95601890afd80709" => "da39a3ee5e6b4b0d3255bfef95601890afd80709"
    vpc_security_group_ids.#:                  "2" => "2"
    vpc_security_group_ids.2560257872:         "sg-1dd8047b" => "sg-1dd8047b"
    vpc_security_group_ids.879210441:          "sg-b268b2d4" => "sg-b268b2d4"

```