### PR TITLE
fix deprecation warning

### DIFF
--- a/instance/iam.tf
+++ b/instance/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_instance_profile" "profile" {
   name  = "profile_${var.name}_${var.project}_${var.environment}"
-  roles = ["${aws_iam_role.role.name}"]
+  role = "${aws_iam_role.role.name}"
 }
 
 resource "aws_iam_role" "role" {


### PR DESCRIPTION
`"roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile`