### PR TITLE
Do not do double lists

### DIFF
--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -46,7 +46,7 @@ module "bastion_host" {
   root_vl_type           = "${var.root_vl_type}"
   root_vl_size           = "${var.root_vl_size}"
   root_vl_delete         = "${var.root_vl_delete}"
-  user_data              = ["${var.user_data}"]
+  user_data              = "${var.user_data}"
   public_ip              = "true"
 }
 


### PR DESCRIPTION
In [0.9.6](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#096-may-25-2017) they fixed the double `[]` and now this gives errors. We can remove the `[]` in one place.