### PR TITLE
Do not create IAM roles if no instances are created

### DIFF
--- a/instance/iam.tf
+++ b/instance/iam.tf
@@ -1,11 +1,12 @@
 resource "aws_iam_instance_profile" "profile" {
   name  = "profile_${var.name}_${var.project}_${var.environment}"
-  role = "${aws_iam_role.role.name}"
+  count = "${var.instance_count == "0" ? 0 : 1}"
+  role  = "${aws_iam_role.role.name}"
 }
 
 resource "aws_iam_role" "role" {
-  name = "role_${var.name}_${var.project}_${var.environment}"
-
+  name  = "role_${var.name}_${var.project}_${var.environment}"
+  count = "${var.instance_count == "0" ? 0 : 1}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/instance/iam.tf
+++ b/instance/iam.tf
@@ -1,12 +1,12 @@
 resource "aws_iam_instance_profile" "profile" {
-  name  = "profile_${var.name}_${var.project}_${var.environment}"
   count = "${var.instance_count == "0" ? 0 : 1}"
+  name  = "profile_${var.name}_${var.project}_${var.environment}"
   role  = "${aws_iam_role.role.name}"
 }
 
 resource "aws_iam_role" "role" {
-  name  = "role_${var.name}_${var.project}_${var.environment}"
   count = "${var.instance_count == "0" ? 0 : 1}"
+  name  = "role_${var.name}_${var.project}_${var.environment}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",


### PR DESCRIPTION
For the moment, it is not possible to add a count to a terraform module.

When we do not want it to be created under a certain environment, we can now specify instance_count to 0 and nothing will be created.