### PR TITLE
allow bastion to have additional block devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Terraform modules to set up a few commonly used instances.
 * [`root_vl_size`]: String(optional)default 30. The size of the volume in gigabytes.
 * [`root_vl_delete`]: Bool(optional)default true. Whether the volume should be destroyed on instance termination
 * [`user_data`]: List(optional)default [""]. The user data to provide when launching the instance. If `instance_count` >1, each instance launched will use user_data with the corresponding `user_data[count.index]`
+* [`ebs_block_devices`]: List(optional)default []. A list of objects defining `ebs_block_device`, as described in the terraform documentation: https://www.terraform.io/docs/providers/aws/r/instance.html#block-devices
+
 
 ### Output
  * [`bastion_sg_id`]: String: The ID of the security group

--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -48,6 +48,7 @@ module "bastion_host" {
   root_vl_delete         = "${var.root_vl_delete}"
   user_data              = "${var.user_data}"
   public_ip              = "true"
+  ebs_block_devices      = ["${var.ebs_block_devices}"]
 }
 
 resource "aws_eip" "bastion_eip" {

--- a/bastion/variables.tf
+++ b/bastion/variables.tf
@@ -73,3 +73,7 @@ variable "user_data" {
   default = [""]
   type    = "list"
 }
+
+variable "ebs_block_devices" {
+  default = []
+}


### PR DESCRIPTION
We need additional ebs volumeson our bastion host. using a `aws_volume_attachment` doesn't work since we already use the inline style.