### PR TITLE
make ebs management in the instance optional

### DIFF
--- a/bastion/main.tf
+++ b/bastion/main.tf
@@ -49,6 +49,7 @@ module "bastion_host" {
   user_data              = "${var.user_data}"
   public_ip              = "true"
   ebs_block_devices      = ["${var.ebs_block_devices}"]
+  ebs_enabled            = "${var.ebs_enabled}"
 }
 
 resource "aws_eip" "bastion_eip" {

--- a/bastion/variables.tf
+++ b/bastion/variables.tf
@@ -77,3 +77,7 @@ variable "user_data" {
 variable "ebs_block_devices" {
   default = []
 }
+
+variable "ebs_enabled" {
+  default = true
+}

--- a/instance/main.tf
+++ b/instance/main.tf
@@ -1,5 +1,5 @@
 resource "aws_instance" "instance" {
-  count                       = "${var.instance_count}"
+  count                       = "${var.ebs_enabled ? var.instance_count : 0}"
   ami                         = "${var.ami}"
   instance_type               = "${var.instance_type}"
   key_name                    = "${var.key_name}"
@@ -18,6 +18,33 @@ resource "aws_instance" "instance" {
   }
 
   ebs_block_device = ["${var.ebs_block_devices}"]
+
+  tags {
+    Name        = "${var.project}-${var.environment}-${var.name}${count.index + 1}"
+    Function    = "${var.name}"
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+  }
+}
+
+resource "aws_instance" "instance_no_ebs" {
+  count                       = "${var.ebs_enabled ? 0 : var.instance_count}"
+  ami                         = "${var.ami}"
+  instance_type               = "${var.instance_type}"
+  key_name                    = "${var.key_name}"
+  iam_instance_profile        = "${aws_iam_instance_profile.profile.id}"
+  vpc_security_group_ids      = ["${var.sgs}"]
+  subnet_id                   = "${element(var.subnets, count.index)}"
+  disable_api_termination     = "${var.termination_protection}"
+  ebs_optimized               = "${var.ebs_optimized}"
+  associate_public_ip_address = "${var.public_ip}"
+  user_data                   = "${element(var.user_data, count.index)}"
+
+  root_block_device {
+    volume_type           = "${var.root_vl_type}"
+    volume_size           = "${var.root_vl_size}"
+    delete_on_termination = "${var.root_vl_delete}"
+  }
 
   tags {
     Name        = "${var.project}-${var.environment}-${var.name}${count.index + 1}"

--- a/instance/outputs.tf
+++ b/instance/outputs.tf
@@ -1,45 +1,45 @@
 output "instance_ids" {
-  value = ["${aws_instance.instance.*.id}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.id : aws_instance.instance_no_ebs.*.id}"]
 }
 
 output "instance_azs" {
-  value = ["${aws_instance.instance.*.availability_zone}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.availability_zone : aws_instance.instance_no_ebs.*.availability_zone}"]
 }
 
 output "instance_placement_groups" {
-  value = ["${aws_instance.instance.*.placement_group}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.placement_group : aws_instance.instance_no_ebs.*.placement_group}"]
 }
 
 output "instance_key_names" {
-  value = ["${aws_instance.instance.*.key_name}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.key_name : aws_instance.instance_no_ebs.*.key_name}"]
 }
 
 output "instance_public_dns" {
-  value = ["${aws_instance.instance.*.public_dns}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.public_dns : aws_instance.instance_no_ebs.*.public_dns}"]
 }
 
 output "instance_public_ips" {
-  value = ["${aws_instance.instance.*.public_ip}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.public_ip : aws_instance.instance_no_ebs.*.public_ip}"]
 }
 
 output "instance_network_interface_ids" {
-  value = ["${aws_instance.instance.*.network_interface_id}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.network_interface_id : aws_instance.instance_no_ebs.*.network_interface_id}"]
 }
 
 output "instance_private_dns" {
-  value = ["${aws_instance.instance.*.private_dns}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.private_dns : aws_instance.instance_no_ebs.*.private_dns}"]
 }
 
 output "instance_private_ip" {
-  value = ["${aws_instance.instance.*.private_ip}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.private_ip : aws_instance.instance_no_ebs.*.private_ip}"]
 }
 
 output "instance_vpc_security_group_ids" {
-  value = ["${aws_instance.instance.*.instance_vpc_security_group_ids}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.instance_vpc_security_group_ids : aws_instance.instance_no_ebs.*.instance_vpc_security_group_ids}"]
 }
 
 output "instance_subnet_ids" {
-  value = ["${aws_instance.instance.*.subnet_id}"]
+  value = ["${var.ebs_enabled ? aws_instance.instance.*.subnet_id : aws_instance.instance_no_ebs.*.subnet_id}"]
 }
 
 output "role_id" {

--- a/instance/variables.tf
+++ b/instance/variables.tf
@@ -60,3 +60,7 @@ variable "tag_value" {
 variable "ebs_block_devices" {
   default = []
 }
+
+variable "ebs_enabled" {
+  default = true
+}


### PR DESCRIPTION
Makes inline ebs management optional. Much easier to manage ebs volumes externally if you don't need them available immediately at boot time.