### PR TITLE
Migrated puppet-userdata module from the terraform-skyscrapers repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,30 @@ module "bastion" {
   instance_type = "t2.micro"
 }
 ```
+
+## puppet-userdata
+
+This module generates a script that bootstraps puppet on the server. It'll install puppet 4 and target `puppetmaster01.int.skyscrape.rs` by default.
+
+### Available variables:
+* [`customer`]: String(required): Customer name
+* [`project`]: String(optional): Name of the project
+* [`environment`]: String(required): Environment it runs in
+* [`function`]: String(required):Function of the server (eg web, db, elasticsearch)
+* [`amount_of_instances`]: String(optional): For how many instances do you need user data. Defaults to 1
+* [`puppetmaster`]: String(optional): Hostname of puppetmaster. Defaults to `puppetmaster01.int.skyscrape.rs`
+* [`domain`]: String(optional): Domain to set as hostname. Defaults to `skyscrape.rs`
+
+### Output
+ * [`user_datas`]: List: The generated user-data script for each instance.
+
+### Example
+```
+module "tools_userdata" {
+  source              = "github.com/skyscrapers/terraform-instances//puppet-userdata?ref=1.0.1"
+  amount_of_instances = "1"
+  environment         = "${terraform.workspace}"
+  customer            = "${var.customer}"
+  function            = "tools"
+}
+```

--- a/puppet-userdata/main.tf
+++ b/puppet-userdata/main.tf
@@ -1,0 +1,14 @@
+data "template_file" "metadata_puppet" {
+  count    = "${var.amount_of_instances}"
+  template = "${file("${path.module}/templates/metadata.tpl")}"
+
+  vars {
+    number       = "${count.index + 1}"
+    environment  = "${var.environment == "production" ? "" : "-${var.environment}"}"
+    project      = "${var.project == "" ? "" : "-${var.project}"}"
+    customer     = "${var.customer}"
+    function     = "${var.function}"
+    puppetmaster = "${var.puppetmaster}"
+    domain       = "${var.domain}"
+  }
+}

--- a/puppet-userdata/outputs.tf
+++ b/puppet-userdata/outputs.tf
@@ -1,0 +1,3 @@
+output "user_datas" {
+  value = ["${data.template_file.metadata_puppet.*.rendered}"]
+}

--- a/puppet-userdata/templates/metadata.tpl
+++ b/puppet-userdata/templates/metadata.tpl
@@ -1,0 +1,2 @@
+#!/bin/bash
+/bin/bash <(/usr/bin/wget -qO- https://raw.githubusercontent.com/skyscrapers/bootstrap/puppet4/autobootstrap.sh) -p ${puppetmaster} -h ${format("%s%s%s-%s%02s", customer, project, environment, function, number)} -f ${format("%s%02s.%s%s%s.${domain}", function, number, customer, project, environment)} -t "UTC"

--- a/puppet-userdata/variables.tf
+++ b/puppet-userdata/variables.tf
@@ -1,0 +1,31 @@
+variable "amount_of_instances" {
+  description = "For how many instances do you need user data"
+  default     = "1"
+}
+
+variable "customer" {
+  description = "Customer name"
+}
+
+variable "project" {
+  description = "Name of the project"
+  default     = ""
+}
+
+variable "environment" {
+  description = "Environment it runs in"
+}
+
+variable "function" {
+  description = "Function of the server (eg web, db, elasticsearch)"
+}
+
+variable "puppetmaster" {
+  description = "Hostname of puppetmaster"
+  default     = "puppetmaster01.int.skyscrape.rs"
+}
+
+variable "domain" {
+  description = "Domain to set as hostname"
+  default     = "skyscrape.rs"
+}


### PR DESCRIPTION
This module already targets the new puppetmaster and installs puppet 4