### PR TITLE
Move the vault service start to cloud-config runcmd section

### DIFF
--- a/vault/templates/configure.yaml.tpl
+++ b/vault/templates/configure.yaml.tpl
@@ -18,9 +18,11 @@ apt:
 
 runcmd:
   - [ pip, install, certbot-dns-route53 ]
-  - [certbot, certonly, -n, --agree-tos, --email, letsencrypt@skyscrapers.eu, --dns-route53, -d, ${vault_dns}]
-  - [chgrp, -R, vault, /etc/letsencrypt]
-  - [chmod, -R, g=rX, /etc/letsencrypt]
+  - [ certbot, certonly, -n, --agree-tos, --email, letsencrypt@skyscrapers.eu, --dns-route53, -d, ${vault_dns} ]
+  - [ chgrp, -R, vault, /etc/letsencrypt ]
+  - [ chmod, -R, g=rX, /etc/letsencrypt ]
+  - [ systemctl, enable, vault.service ]
+  - [ systemctl, start, vault.service ]
 
 write_files:
 - content: |

--- a/vault/templates/install.sh.tpl
+++ b/vault/templates/install.sh.tpl
@@ -15,7 +15,3 @@ sudo chown root:root /usr/local/bin/vault
 sudo /tmp/teleport/install
 
 sudo systemctl daemon-reload
-sudo systemctl enable vault.service
-sudo systemctl start vault.service
-sudo systemctl enable teleport.service
-sudo systemctl start teleport.service


### PR DESCRIPTION
Standalone scripts are run before the `runcmd` section in cloud-config, so the vault service was being started before the LetsEncrypt certs were created, making it fail. This will start Vault after the certs are created.

Source: http://cloudinit.readthedocs.io/en/latest/topics/boot.html