### PR TITLE
Use name_prefix instead of a fixed name for the vault security group

### DIFF
--- a/vault/sg.tf
+++ b/vault/sg.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "vault" {
-  name        = "vault"
+  name_prefix = "vault_${var.project}_"
   description = "vault specific rules"
   vpc_id      = "${var.vpc_id}"
 


### PR DESCRIPTION
Naming it just "vault" is risky as there might be another security group named like that.