### PR TITLE
fixing output for terraform 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Terraform modules to set up a few commonly used instances.
  * [`bastion_sg_id`]: String: The ID of the security group
  * [`instance_id`]: String: The instance IDs.
  * [`instance_az`]: String: The availability zone of the instances.
- * [`instance_placement_group`]: String: The placement group of the instances
  * [`instance_key_name`]: String: The key name of the instances
  * [`instance_public_dns`]: String: The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC
  * [`instance_public_ip`]: String: The public IP address assigned to the bastion. NOTE: If you are using an aws_eip with your instance, you should refer to the EIP's address directly and not use public_ip, as this field will change after the EIP is attached.
@@ -84,7 +83,6 @@ module "bastion" {
  * [`role_id`]: String: The ID of the role
  * [`instance_ids`]: List: The instance IDs.
  * [`instance_azs`]: List: The availability zone of the instances.
- * [`instance_placement_groups`]: List: The placement group of the instances
  * [`instance_key_names`]: List: The key name of the instances
  * [`instance_public_dns`]: List: The public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC
  * [`instance_public_ips`]: List: The public IP address assigned to the instance, if applicable. NOTE: If you are using an aws_eip with your instance, you should refer to the EIP's address directly and not use public_ip, as this field will change after the EIP is attached.

--- a/bastion/outputs.tf
+++ b/bastion/outputs.tf
@@ -10,10 +10,6 @@ output "instance_az" {
   value = "${module.bastion_host.instance_azs[0]}"
 }
 
-output "instance_placement_group" {
-  value = "${module.bastion_host.instance_placement_groups[0]}"
-}
-
 output "instance_key_name" {
   value = "${module.bastion_host.instance_key_names[0]}"
 }

--- a/instance/outputs.tf
+++ b/instance/outputs.tf
@@ -6,10 +6,6 @@ output "instance_azs" {
   value = ["${concat(aws_instance.instance.*.availability_zone, aws_instance.instance_no_ebs.*.availability_zone) }"]
 }
 
-output "instance_placement_groups" {
-  value = ["${concat(aws_instance.instance.*.placement_group, aws_instance.instance_no_ebs.*.placement_group)}"]
-}
-
 output "instance_key_names" {
   value = ["${concat(aws_instance.instance.*.key_name, aws_instance.instance_no_ebs.*.key_name)}"]
 }


### PR DESCRIPTION
The placement group apparently is a parameter that is not present anymore in terraform 0.11 according to @iuriaranda's analysis. 

Currently it's giving the following error:

```
module.tools.module.bastion_host.output.instance_placement_groups: Resource 'aws_instance.instance_no_ebs' does not have attribute 'placement_group' for variable 'aws_instance.instance_no_ebs.*.placement_group'
```