### PR TITLE
Change teleport systemd file to use environmentfile

### DIFF
--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -68,7 +68,7 @@ data "template_file" "install" {
 }
 
 module "teleport_vault1" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=2.1.2"
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=2.2.0"
   auth_server = "${var.teleport_auth_server}"
   auth_token  = "${var.teleport_token_1}"
   function    = "vault1"
@@ -76,7 +76,7 @@ module "teleport_vault1" {
 }
 
 module "teleport_vault2" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=2.1.2"
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=2.2.0"
   auth_server = "${var.teleport_auth_server}"
   auth_token  = "${var.teleport_token_2}"
   function    = "vault2"

--- a/vault/templates/configure.yaml.tpl
+++ b/vault/templates/configure.yaml.tpl
@@ -26,12 +26,6 @@ runcmd:
 
 write_files:
 - content: |
-    teleport:
-      nodename: $NODENAME
-      auth_token: $AUTH_TOKEN
-      advertise_ip: $ADVERTISE_IP
-      auth_servers:
-        - $AUTH_SERVER
     ssh_service:
       enabled: yes
       listen_addr: 0.0.0.0:3022
@@ -52,9 +46,10 @@ write_files:
     After=network.target
 
     [Service]
+    EnvironmentFile=/etc/teleport
     Type=simple
     Restart=on-failure
-    ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml
+    ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --nodename $NODENAME --advertise-ip $ADVERTISE_IP --auth-server $AUTH_SERVER --token $AUTH_TOKEN
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
Instead of putting values in the teleport.yaml file that we have to replace at startup, use an environmentfile in systemd to get those variables.