### PR TITLE
Fine tune the network settings for Vault

### DIFF
--- a/vault/templates/install.sh.tpl
+++ b/vault/templates/install.sh.tpl
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Time before the kernel kills a connection in CLOSE_WAIT
+# reduced to 5 minutes as Vault keeps a lot of connections
+echo 'net.ipv4.tcp_keepalive_time = 300' >> /etc/sysctl.conf
+sysctl -p
+
 curl -L "${download_url_vault}" > /tmp/vault.zip
 curl -L "${download_url_teleport}" > /tmp/teleport.tar.gz
 


### PR DESCRIPTION
Reduced the time before the kernel kills a connection in CLOSE_WAIT to 5 minutes, as Vault keeps a lot of connections open in that state, resulting in error for too many files open. Probably a bug in Vault.