### PR TITLE
Make teleport optional for setting up vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ Both vault servers are configured with Teleport for SSH management.
 * [`dns_root`]: String(required): The root domain to configure for vault
 * [`lb_subnets`]: List(required): The subnets to use for the alb
 * [`key_name`]: String(required): Name of the sshkey to deploy on the vault instances
-* [`teleport_auth_server`]: String(required): The hostname or ip of the Teleport auth server.
-* [`teleport_node_sg`]: String(required): The security-group ID of the teleport server.
-* [`teleport_token_1`]: String(required): The Teleport token for the first instance. This can be a dynamic short-lived token.
-* [`teleport_token_2`]: String(required): The Teleport token for the second instance. This can be a dynamic short-lived token.
+* [`teleport_auth_server`]: String(optional): The hostname or ip of the Teleport auth server.
+* [`teleport_node_sg`]: String(optional): The security-group ID of the teleport server.
+* [`teleport_token_1`]: String(optional): The Teleport token for the first instance. This can be a dynamic short-lived token.
+* [`teleport_token_2`]: String(optional): The Teleport token for the second instance. This can be a dynamic short-lived token.
 * [`vault1_subnet`]: String(required): The subnet ID for the first vault instance
 * [`vault2_subnet`]: String(required): The subnet ID for the second vault instance
 * [`vpc_id`]: String(required): The VPC id to launch the instances in.

--- a/README.md
+++ b/README.md
@@ -138,19 +138,20 @@ module "tools_userdata" {
 This terraform module sets up a HA vault with a DynamoDB backend.
 The module sets up TLS using Letsencrypt with dns-01 challenge.
 
-Both vault servers are configured with Teleport for SSH management.
+Both vault servers are optionally configured with Teleport for SSH management.
 
-2 route53 records are provided to access the individual instances.
+Two route53 records are provided to access the individual instances.
 
 ![](vault/images/vault-component.svg)
 
-### Available variables:
+### Available variables
+
 * [`acm_arn`]: String(required): The ACM ARN to use on the alb
 * [`ami`]: String(required): The AMI ID to use for the vault instances
 * [`dns_root`]: String(required): The root domain to configure for vault
 * [`lb_subnets`]: List(required): The subnets to use for the alb
 * [`key_name`]: String(required): Name of the sshkey to deploy on the vault instances
-* [`teleport_auth_server`]: String(optional): The hostname or ip of the Teleport auth server.
+* [`teleport_auth_server`]: String(optional): The hostname or ip of the Teleport auth server. If empty, Teleport integration will be disabled (default).
 * [`teleport_node_sg`]: String(optional): The security-group ID of the teleport server.
 * [`teleport_token_1`]: String(optional): The Teleport token for the first instance. This can be a dynamic short-lived token.
 * [`teleport_token_2`]: String(optional): The Teleport token for the second instance. This can be a dynamic short-lived token.
@@ -166,24 +167,26 @@ Both vault servers are configured with Teleport for SSH management.
 * [`vault_nproc`]: String(optional): The amount of nproc to configure vault with. Set this to the amount of CPU cores. Defaults to 1
 
 ### Output
- * [`sg_id`]: String: The vault security-group id
- * [`vault_route53_record`]: String: The main vault route53 record id
- * [`vault1_route53_record`]: String: The vault1 route53 record id
- * [`vault2_route53_record`]: String: The vault2 route53 record id
- * [`vault1_instance_id`]: String: The vault1 instance ID
- * [`vault2_instance_id`]: String: The vault2 instance ID
- * [`vault1_role_id`]: String: The vault1 instance-role ID
- * [`vault2_role_id`]: String: The vault2 instance-role ID
- * [`iam_policy`]: String: The iam policy ARN used for vault
- * [`alb_main_target_group`]: String: The default alb target group ARN
- * [`alb_vault1_target_group`]: String: The vault1 target group ARN
- * [`alb_vault2_target_group`]: String: The vault2 target group ARN
- * [`alb_sg_id`]: String: The alb security group ID
- * [`alb_id`]: String: The alb id
- * [`alb_arn`]: String: The alb ARN
+
+* [`sg_id`]: String: The vault security-group id
+* [`vault_route53_record`]: String: The main vault route53 record id
+* [`vault1_route53_record`]: String: The vault1 route53 record id
+* [`vault2_route53_record`]: String: The vault2 route53 record id
+* [`vault1_instance_id`]: String: The vault1 instance ID
+* [`vault2_instance_id`]: String: The vault2 instance ID
+* [`vault1_role_id`]: String: The vault1 instance-role ID
+* [`vault2_role_id`]: String: The vault2 instance-role ID
+* [`iam_policy`]: String: The iam policy ARN used for vault
+* [`alb_main_target_group`]: String: The default alb target group ARN
+* [`alb_vault1_target_group`]: String: The vault1 target group ARN
+* [`alb_vault2_target_group`]: String: The vault2 target group ARN
+* [`alb_sg_id`]: String: The alb security group ID
+* [`alb_id`]: String: The alb id
+* [`alb_arn`]: String: The alb ARN
 
 ### Example
-```
+
+```terraform
 module "ha_vault" {
   source               = "github.com/skyscrapers/terraform-instances//vault?ref=2.0.0"
   teleport_auth_server = "10.10.0.100:3025"

--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -14,7 +14,7 @@ data "template_cloudinit_config" "vault1" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${module.teleport_vault1.teleport_bootstrap_script}"
+    content      = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_bootstrap_script}"
   }
 }
 
@@ -34,7 +34,7 @@ data "template_cloudinit_config" "vault2" {
 
   part {
     content_type = "text/x-shellscript"
-    content      = "${module.teleport_vault2.teleport_bootstrap_script}"
+    content      = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_bootstrap_script}"
   }
 }
 
@@ -45,8 +45,8 @@ data "template_file" "cloudconfig_vault1" {
     vault_dns         = "vault1.${var.dns_root}"
     vault_nproc       = "${var.vault_nproc}"
     vault_cluster_dns = "vault.${var.dns_root}"
-    teleport_config   = "${module.teleport_vault1.teleport_config_cloudinit}"
-    teleport_service  = "${module.teleport_vault1.teleport_service_cloudinit}"
+    teleport_config   = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_config_cloudinit}"
+    teleport_service  = "${var.teleport_auth_server == "" ? "" : module.teleport_vault1.teleport_service_cloudinit}"
   }
 }
 
@@ -57,8 +57,8 @@ data "template_file" "cloudconfig_vault2" {
     vault_dns         = "vault2.${var.dns_root}"
     vault_nproc       = "${var.vault_nproc}"
     vault_cluster_dns = "vault.${var.dns_root}"
-    teleport_config   = "${module.teleport_vault2.teleport_config_cloudinit}"
-    teleport_service  = "${module.teleport_vault2.teleport_service_cloudinit}"
+    teleport_config   = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_config_cloudinit}"
+    teleport_service  = "${var.teleport_auth_server == "" ? "" : module.teleport_vault2.teleport_service_cloudinit}"
   }
 }
 
@@ -68,6 +68,7 @@ data "template_file" "install" {
   vars {
     download_url_vault    = "${var.download_url_vault}"
     download_url_teleport = "${var.download_url_teleport}"
+    teleport_auth_server  = "${var.teleport_auth_server}"
   }
 }
 

--- a/vault/instances.tf
+++ b/vault/instances.tf
@@ -1,9 +1,13 @@
+locals {
+  security_groups = "${compact(list(aws_security_group.vault.id, var.teleport_node_sg))}"
+}
+
 module "vault1" {
-  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.0.8"
+  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.0.15"
   project       = "${var.project}"
   environment   = "${terraform.workspace}"
   name          = "vault1"
-  sgs           = ["${aws_security_group.vault.id}", "${var.teleport_node_sg}"]
+  sgs           = "${local.security_groups}"
   subnets       = ["${var.vault1_subnet}"]
   key_name      = "${var.key_name}"
   ami           = "${var.ami}"
@@ -12,11 +16,11 @@ module "vault1" {
 }
 
 module "vault2" {
-  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.0.8"
+  source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.0.15"
   project       = "${var.project}"
   environment   = "${terraform.workspace}"
   name          = "vault2"
-  sgs           = ["${aws_security_group.vault.id}", "${var.teleport_node_sg}"]
+  sgs           = "${local.security_groups}"
   subnets       = ["${var.vault2_subnet}"]
   key_name      = "${var.key_name}"
   ami           = "${var.ami}"

--- a/vault/templates/install.sh.tpl
+++ b/vault/templates/install.sh.tpl
@@ -6,17 +6,20 @@ set -e
 echo 'net.ipv4.tcp_keepalive_time = 300' >> /etc/sysctl.conf
 sysctl -p
 
-curl -L "${download_url_vault}" > /tmp/vault.zip
-curl -L "${download_url_teleport}" > /tmp/teleport.tar.gz
-
 cd /tmp
-sudo unzip vault.zip
-sudo tar -xzf teleport.tar.gz
 
+curl -L "${download_url_vault}" > /tmp/vault.zip
+
+sudo unzip vault.zip
 sudo mv vault /usr/local/bin
 sudo chmod 0755 /usr/local/bin/vault
 sudo chown root:root /usr/local/bin/vault
 
-sudo /tmp/teleport/install
+if [ -z "${teleport_auth_server}" ]; then
+  curl -L "${download_url_teleport}" > /tmp/teleport.tar.gz
+
+  sudo tar -xzf teleport.tar.gz
+  sudo /tmp/teleport/install
+fi
 
 sudo systemctl daemon-reload

--- a/vault/templates/install.sh.tpl
+++ b/vault/templates/install.sh.tpl
@@ -15,7 +15,7 @@ sudo mv vault /usr/local/bin
 sudo chmod 0755 /usr/local/bin/vault
 sudo chown root:root /usr/local/bin/vault
 
-if [ -z "${teleport_auth_server}" ]; then
+if [ -n "${teleport_auth_server}" ]; then
   curl -L "${download_url_teleport}" > /tmp/teleport.tar.gz
 
   sudo tar -xzf teleport.tar.gz

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -14,14 +14,29 @@ variable "download_url_vault" {
 }
 
 variable "download_url_teleport" {
-  default = "https://github.com/gravitational/teleport/releases/download/v2.3.5/teleport-v2.3.5-linux-amd64-bin.tar.gz"
+  description = "String(optional): The download url for Teleport."
+  default     = "https://github.com/gravitational/teleport/releases/download/v2.3.5/teleport-v2.3.5-linux-amd64-bin.tar.gz"
 }
 
-variable "teleport_auth_server" {}
+variable "teleport_auth_server" {
+  description = "String(optional): The hostname or ip of the Teleport auth server."
+  default     = ""
+}
 
-variable "teleport_token_1" {}
+variable "teleport_token_1" {
+  description = "String(optional): The Teleport token for the first instance. This can be a dynamic short-lived token."
+  default     = ""
+}
 
-variable "teleport_token_2" {}
+variable "teleport_token_2" {
+  description = "String(optional): The Teleport token for the second instance. This can be a dynamic short-lived token."
+  default     = ""
+}
+
+variable "teleport_node_sg" {
+  description = "String(optional): The security-group ID of the teleport server."
+  default     = ""
+}
 
 variable "instance_type" {
   default = "t2.micro"
@@ -32,8 +47,6 @@ variable "ami" {}
 variable "vault1_subnet" {}
 
 variable "vault2_subnet" {}
-
-variable "teleport_node_sg" {}
 
 variable "acm_arn" {}
 


### PR DESCRIPTION
This makes it possible to setup Vault without Teleport (so no SSH access possible, except for the aws-provided key).