### PR TITLE
Use `var.environment` instead of `terraform.workspace` in Vault module

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Two route53 records are provided to access the individual instances.
 * [`instance_type`]: String(optional): The instance type to use for the vault servers. Defaults to t2.micro
 * [`lb_internal`]: Bool(optional): Should the ALB be created as an internal Loadbalancer
 * [`project`]: String(required): Name of the project
+* [`environment`]: String(required): Name of the environment where to deploy Vault (just for naming reasons)
 * [`vault_nproc`]: String(optional): The amount of nproc to configure vault with. Set this to the amount of CPU cores. Defaults to 1
 
 ### Output

--- a/vault/alb.tf
+++ b/vault/alb.tf
@@ -1,7 +1,7 @@
 module "alb" {
   source                       = "github.com/skyscrapers/terraform-loadbalancers//alb?ref=3.1.2"
   name                         = "vault"
-  environment                  = "${terraform.workspace}"
+  environment                  = "${var.environment}"
   project                      = "${var.project}"
   vpc_id                       = "${var.vpc_id}"
   subnets                      = "${var.lb_subnets}"

--- a/vault/cloud-config.tf
+++ b/vault/cloud-config.tf
@@ -77,7 +77,7 @@ module "teleport_vault1" {
   auth_server = "${var.teleport_auth_server}"
   auth_token  = "${var.teleport_token_1}"
   function    = "vault1"
-  environment = "${terraform.workspace}"
+  environment = "${var.environment}"
 }
 
 module "teleport_vault2" {
@@ -85,5 +85,5 @@ module "teleport_vault2" {
   auth_server = "${var.teleport_auth_server}"
   auth_token  = "${var.teleport_token_2}"
   function    = "vault2"
-  environment = "${terraform.workspace}"
+  environment = "${var.environment}"
 }

--- a/vault/instances.tf
+++ b/vault/instances.tf
@@ -5,7 +5,7 @@ locals {
 module "vault1" {
   source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.2"
   project       = "${var.project}"
-  environment   = "${terraform.workspace}"
+  environment   = "${var.environment}"
   name          = "vault1"
   sgs           = "${local.security_groups}"
   subnets       = ["${var.vault1_subnet}"]
@@ -18,7 +18,7 @@ module "vault1" {
 module "vault2" {
   source        = "github.com/skyscrapers/terraform-instances//instance?ref=2.3.2"
   project       = "${var.project}"
-  environment   = "${terraform.workspace}"
+  environment   = "${var.environment}"
   name          = "vault2"
   sgs           = "${local.security_groups}"
   subnets       = ["${var.vault2_subnet}"]

--- a/vault/variables.tf
+++ b/vault/variables.tf
@@ -1,5 +1,7 @@
 variable "project" {}
 
+variable "environment" {}
+
 variable "lb_internal" {
   default = false
 }


### PR DESCRIPTION
`terraform.workspace` should be used only in top-level stacks, not inside modules, as it restricts a lot the usage of workspace names.
The caller of the module can always set the `environment` variable with the value of `terraform.workspace` in any case

Not a breaking change, so I'll just bump a minor version number.