### PR TITLE
replace deprecated network_interface_id

### DIFF
--- a/instance/outputs.tf
+++ b/instance/outputs.tf
@@ -19,7 +19,7 @@ output "instance_public_ips" {
 }
 
 output "instance_network_interface_ids" {
-  value = ["${concat(aws_instance.instance.*.network_interface_id, aws_instance.instance_no_ebs.*.network_interface_id)}"]
+  value = ["${concat(aws_instance.instance.*.primary_network_interface_id, aws_instance.instance_no_ebs.*.primary_network_interface_id)}"]
 }
 
 output "instance_private_dns" {


### PR DESCRIPTION
New AWS provider version 2.0 removed support for output `network_interface_id` in favor of `primary_network_interface_id`

Further details:
https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#200-february-27-2019
https://github.com/terraform-providers/terraform-provider-aws/pull/1193
